### PR TITLE
Fixes CStyles always calculating their own byte length

### DIFF
--- a/Engine/API/Types/String/CStyleString.hpp
+++ b/Engine/API/Types/String/CStyleString.hpp
@@ -12,10 +12,11 @@ namespace CYB {
 				/*!
 					@brief Construct a CStyle string
 					@param AData The data to populate the char array with. Must be at least a pointer to a null terminating character
+					@param ALength The length of AData. Looks instead for '\0' if set to -1
 					@par Thread Safety
 						This function requires no thread safety
 				*/
-				CStyle(char* const AData) noexcept;
+				CStyle(char* const AData, const int ALength) noexcept;
 				virtual ~CStyle() = default;
 				/*!
 					@brief Calculate the byte length of the contained CString

--- a/Engine/API/Types/String/CStyleString.inl
+++ b/Engine/API/Types/String/CStyleString.inl
@@ -1,9 +1,9 @@
 //! @file CStyleString.inl Implements functions from CYB::API::String::CStyle
 #pragma once
 
-inline CYB::API::String::CStyle::CStyle(char* const AData) noexcept :
+inline CYB::API::String::CStyle::CStyle(char* const AData, const int ALength) noexcept :
 	FData(AData),
-	FLength(CalculateByteLength())
+	FLength(ALength == -1 ? CalculateByteLength() : ALength)
 {}
 
 inline int CYB::API::String::CStyle::CalculateByteLength(void) const noexcept {

--- a/Engine/API/Types/String/DynamicString.hpp
+++ b/Engine/API/Types/String/DynamicString.hpp
@@ -72,14 +72,14 @@ namespace CYB {
 				/*!
 					@brief Construct a Dynamic string. This will allocate enough data to copy the contents of @p AData
 					@param AData The data to populate the char array with
-					@param ALength The length of AData to copy. Looks instead for '\0' if set to -1
+					@param ALength The length of AData to copy. Uses @p AData's RawLength() if set to -1
 					@par Thread Safety
 						This function requires no thread safety
 					@throws CYB::Exception::SystemData Error code: CYB::Exception::SystemData::HEAP_ALLOCATION_FAILURE. Thrown if the current heap runs out of memory
 				*/
 				Dynamic(const CStyle& AData, const int ALength = -1);
 				/*!
-					@brief See @ref structors
+					@brief Copies the FData of @p ACopy for its FLength bytes
 					@param ACopy a reference to the existing Dynamic to copy
 					@throws CYB::Exception::SystemData Error code: CYB::Exception::SystemData::HEAP_ALLOCATION_FAILURE. Thrown if the current heap runs out of memory
 				*/

--- a/Engine/API/Types/String/DynamicString.inl
+++ b/Engine/API/Types/String/DynamicString.inl
@@ -17,7 +17,7 @@ inline CYB::API::String::Dynamic::Dynamic(const CStyle& AData, const int ALength
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const Dynamic& ACopy) :
-	Dynamic(static_cast<const CStyle&>(ACopy), ACopy.FLength)
+	Dynamic(static_cast<const CStyle&>(ACopy))
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(Dynamic&& AMove) noexcept :

--- a/Engine/API/Types/String/DynamicString.inl
+++ b/Engine/API/Types/String/DynamicString.inl
@@ -1,19 +1,19 @@
 #pragma once
 
 inline CYB::API::String::Dynamic::Dynamic() noexcept :
-	CStyle(nullptr)
+	CStyle(nullptr, -1)
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(char* const AData) noexcept :
-	CStyle(AData)
+	CStyle(AData, -1)
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const char* const AData, const int ALength) :
-	CStyle(CopyCStyle(Static(AData), ALength))
+	CStyle(CopyCStyle(Static(AData), ALength), ALength)
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const CStyle& AData, const int ALength) :
-	CStyle(CopyCStyle(AData, ALength))
+	CStyle(CopyCStyle(AData, ALength), ALength)
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const Dynamic& ACopy) :
@@ -21,7 +21,7 @@ inline CYB::API::String::Dynamic::Dynamic(const Dynamic& ACopy) :
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(Dynamic&& AMove) noexcept :
-	CStyle(AMove.FData)
+	CStyle(AMove.FData, AMove.FLength)
 {
 	AMove.FData = nullptr;
 }

--- a/Engine/API/Types/String/DynamicString.inl
+++ b/Engine/API/Types/String/DynamicString.inl
@@ -17,7 +17,7 @@ inline CYB::API::String::Dynamic::Dynamic(const CStyle& AData, const int ALength
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const Dynamic& ACopy) :
-	Dynamic(static_cast<const CStyle&>(ACopy))
+	Dynamic(static_cast<const CStyle&>(ACopy), ACopy.FLength)
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(Dynamic&& AMove) noexcept :

--- a/Engine/API/Types/String/StaticString.inl
+++ b/Engine/API/Types/String/StaticString.inl
@@ -6,7 +6,7 @@ inline CYB::API::String::Static::Static() noexcept :
 {}
 
 inline CYB::API::String::Static::Static(const char* const AData) noexcept :
-	CStyle(const_cast<char*>(AData))	//Valid af since the data is immutable
+	CStyle(const_cast<char*>(AData), -1)	//Valid af since the data is immutable
 {}
 
 inline int CYB::API::String::Static::Length(void) const noexcept {


### PR DESCRIPTION
Trying to think of any side effects, why would we want to recalculate length every time we copy a string.

Fixes #19 