### PR TITLE
Fixes Dynamics' copy constructor not taking the source's length

### DIFF
--- a/Engine/API/Types/String/DynamicString.inl
+++ b/Engine/API/Types/String/DynamicString.inl
@@ -17,7 +17,7 @@ inline CYB::API::String::Dynamic::Dynamic(const CStyle& AData, const int ALength
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(const Dynamic& ACopy) :
-	Dynamic(static_cast<const CStyle&>(ACopy))
+	Dynamic(ACopy, ACopy.RawLength())
 {}
 
 inline CYB::API::String::Dynamic::Dynamic(Dynamic&& AMove) noexcept :


### PR DESCRIPTION
Follow-up to #18 
Fixes #19 