### PR TITLE
Moves ENABLE_TEST_HOOKS basic definition from CYB.hpp to SystemChecks.hpp

### DIFF
--- a/Engine/API/Declarations/SystemChecks.hpp
+++ b/Engine/API/Declarations/SystemChecks.hpp
@@ -29,3 +29,7 @@ static_assert(
 	&& sizeof(void*) == 8,
 	"A type size assertion failed");
 static_assert(CYB::API::Endianess::Get() == CYB::API::Endianess::Type::LITTLE_ENDIAN, "CyberEngineMkIII relies on a little endian architecture");
+
+#ifndef ENABLE_TEST_HOOKS
+#define ENABLE_TEST_HOOKS
+#endif

--- a/Engine/CYB.hpp
+++ b/Engine/CYB.hpp
@@ -3,9 +3,6 @@
 #define EXPLICIT_CYB_API_USAGE
 #define ASSERTION_OVERRIDE
 #define CORE_DEFINED_CONTEXT
-#ifndef ENABLE_TEST_HOOKS
-#define ENABLE_TEST_HOOKS
-#endif
 
 #include "API/CyberEngine.hpp"
 


### PR DESCRIPTION
Fixes #29