### PR TITLE
Fixes a bad return of CreateDirectory in Win32

### DIFF
--- a/Engine/Platform/System/Win32/CYBWin32Path.hpp
+++ b/Engine/Platform/System/Win32/CYBWin32Path.hpp
@@ -52,6 +52,15 @@ namespace CYB {
 				protected:
 					API::String::UTF16 FWidePath;	//!< @brief The UTF16 string
 				protected:
+					/*!
+						@brief Try to check for the existence of a directory
+						@param APath The path of the directory to check
+						@return -1 if an error occured. 0 if @p APath is not a directory. 1 if @p APath is a directory
+						@par Thread Safety
+							This function requires no thread safety
+					*/
+					static int CheckDirectoryExists(const API::String::UTF16& APath) noexcept;
+
 					Path() noexcept = default;	//!< @brief See @ref structors
 				public:
 					/*!

--- a/Tests/Platform/System/Path.cpp
+++ b/Tests/Platform/System/Path.cpp
@@ -662,7 +662,9 @@ SCENARIO("Paths can be created by the system", "[Platform][System][Path][Unit]")
 		}
 		WHEN("The temporary directory is retrieved") {
 			//for code coverage purposes, fake the directory creation
+#ifdef TARGET_OS_WINDOWS
 			const auto BGFA(K32.Redirect<CYB::Platform::Modules::Kernel32::GetFileAttributesExW, BadGetFileAttributesEx>());
+#endif
 			const auto DoTest([&]() {
 				REQUIRE_NOTHROW(TestPath = new Path(Path::SystemPath::TEMPORARY));
 				THEN("All is well") {
@@ -860,7 +862,9 @@ SCENARIO("Path errors work", "[Platform][System][Path][Unit]") {
 			}
 		}
 		{
+#ifdef TARGET_OS_WINDOWS
 			const auto BGFA(K32.Redirect<CYB::Platform::Modules::Kernel32::GetFileAttributesExW, BadGetFileAttributesEx>());
+#endif
 			const auto BCD(K32.Redirect<CYB::Platform::Modules::Kernel32::CreateDirectoryW, BadCreateDirectory>());
 			const auto BGLE(K32.Redirect<CYB::Platform::Modules::Kernel32::GetLastError, BadGetLastError>());
 			const auto BMD(LibC.Redirect<CYB::Platform::Modules::LibC::mkdir, BadMkDir>());

--- a/Tests/Platform/System/Path.cpp
+++ b/Tests/Platform/System/Path.cpp
@@ -662,10 +662,23 @@ SCENARIO("Paths can be created by the system", "[Platform][System][Path][Unit]")
 		}
 		WHEN("The temporary directory is retrieved") {
 			//for code coverage purposes, fake the directory creation
-			const auto GCD(K32.Redirect<CYB::Platform::Modules::Kernel32::CreateDirectoryW, GoodCreateDirectory>());
-			REQUIRE_NOTHROW(TestPath = new Path(Path::SystemPath::TEMPORARY));
-			THEN("All is well") {
-				CHECK(TestPath != nullptr);
+			const auto BGFA(K32.Redirect<CYB::Platform::Modules::Kernel32::GetFileAttributesExW, BadGetFileAttributesEx>());
+			const auto DoTest([&]() {
+				REQUIRE_NOTHROW(TestPath = new Path(Path::SystemPath::TEMPORARY));
+				THEN("All is well") {
+					CHECK(TestPath != nullptr);
+				}
+			});
+			AND_WHEN("We succeed normally") {
+				const auto GCD(K32.Redirect<CYB::Platform::Modules::Kernel32::CreateDirectoryW, GoodCreateDirectory>());
+				DoTest();
+			}
+			AND_WHEN("We fail with ERROR_ALREADY_EXISTS") {
+				const auto GCD(K32.Redirect<CYB::Platform::Modules::Kernel32::CreateDirectoryW, BadCreateDirectory>());
+#ifdef TARGET_OS_WINDOWS
+				const auto FakeError(OverrideError(K32, ERROR_ALREADY_EXISTS));
+#endif
+				DoTest();
 			}
 		}
 		WHEN("The user directory is retrieved") {
@@ -847,6 +860,7 @@ SCENARIO("Path errors work", "[Platform][System][Path][Unit]") {
 			}
 		}
 		{
+			const auto BGFA(K32.Redirect<CYB::Platform::Modules::Kernel32::GetFileAttributesExW, BadGetFileAttributesEx>());
 			const auto BCD(K32.Redirect<CYB::Platform::Modules::Kernel32::CreateDirectoryW, BadCreateDirectory>());
 			const auto BGLE(K32.Redirect<CYB::Platform::Modules::Kernel32::GetLastError, BadGetLastError>());
 			const auto BMD(LibC.Redirect<CYB::Platform::Modules::LibC::mkdir, BadMkDir>());


### PR DESCRIPTION
Relying on create directory to return ERROR_ALREADY_EXISTS turns out to be not enough. If there are files open in that directory, it could, in fact, return ERROR_ACCESS_DENIED. Instead we should actually do a hard check before trying to create it