### PR TITLE
Mutex Safety Increase

### DIFF
--- a/Engine/Platform/System/Posix/CYBPosixMutex.cpp
+++ b/Engine/Platform/System/Posix/CYBPosixMutex.cpp
@@ -19,12 +19,16 @@ CYB::Platform::System::Mutex::~Mutex() {
 
 void CYB::Platform::System::Mutex::Lock(void) noexcept {
 	Core().FModuleManager.Call<Modules::PThread::pthread_mutex_lock>(&FMutex);
+	std::atomic_thread_fence(std::memory_order_acquire);
 }
 
 bool CYB::Platform::System::Mutex::TryLock(void) noexcept {
-	return Core().FModuleManager.Call<Modules::PThread::pthread_mutex_trylock>(&FMutex) == 0;
+	const auto Result(Core().FModuleManager.Call<Modules::PThread::pthread_mutex_trylock>(&FMutex) == 0);
+	std::atomic_thread_fence(std::memory_order_acquire);
+	return Result;
 }
 
 void CYB::Platform::System::Mutex::Unlock(void) noexcept {
+	std::atomic_thread_fence(std::memory_order_release);
 	Core().FModuleManager.Call<Modules::PThread::pthread_mutex_unlock>(&FMutex);
 }

--- a/Engine/Platform/System/Posix/CYBPosixMutex.cpp
+++ b/Engine/Platform/System/Posix/CYBPosixMutex.cpp
@@ -13,8 +13,7 @@ CYB::Platform::System::Mutex::Mutex() {
 }
 
 CYB::Platform::System::Mutex::~Mutex() {
-	const auto Result(Core().FModuleManager.Call<Modules::PThread::pthread_mutex_destroy>(&FMutex));
-	API::Assert::Equal(Result, 0);
+	Core().FModuleManager.Call<Modules::PThread::pthread_mutex_destroy>(&FMutex);
 }
 
 void CYB::Platform::System::Mutex::Lock(void) noexcept {

--- a/Engine/Platform/System/Win32/CYBWin32Mutex.cpp
+++ b/Engine/Platform/System/Win32/CYBWin32Mutex.cpp
@@ -11,12 +11,16 @@ CYB::Platform::System::Mutex::~Mutex() {
 
 void CYB::Platform::System::Mutex::Lock(void) noexcept {
 	Core().FModuleManager.Call<Modules::Kernel32::EnterCriticalSection>(&FCriticalSection);
+	std::atomic_thread_fence(std::memory_order_acquire);
 }
 
 bool CYB::Platform::System::Mutex::TryLock(void) noexcept {
-	return Core().FModuleManager.Call<Modules::Kernel32::TryEnterCriticalSection>(&FCriticalSection) == TRUE;
+	const auto Result(Core().FModuleManager.Call<Modules::Kernel32::TryEnterCriticalSection>(&FCriticalSection) == TRUE);
+	std::atomic_thread_fence(std::memory_order_acquire);
+	return Result;
 }
 
 void CYB::Platform::System::Mutex::Unlock(void) noexcept {
+	std::atomic_thread_fence(std::memory_order_release);
 	Core().FModuleManager.Call<Modules::Kernel32::LeaveCriticalSection>(&FCriticalSection);
 }


### PR DESCRIPTION
Add explicit memory fences to make the transition clear.

Remove a rogue Assert.
